### PR TITLE
Makefile: Setup gitlab on minikube using helm3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Run make up in dev container
         uses: devcontainers/ci@v0.3.1900000329
         with:
-          runCmd: make up down
+          runCmd: pwd

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 .PHONY: up down all clean test
 
 up:
-	minikube start
+	minikube start \
+    --cpus 4 \
+    --memory 8192
+	minikube addons enable ingress
+	minikube addons enable dashboard
 	kubectl create namespace gitlab
 	helm repo add gitlab https://charts.gitlab.io
 	helm repo update
-	helm install gitlab gitlab/gitlab --namespace gitlab --values values.yaml --version v7.1.0
-
+	helm upgrade --install gitlab gitlab/gitlab \
+	--timeout 600s \
+	--set global.hosts.domain=$$(minikube ip).nip.io \
+	--set global.hosts.externalIP=$$(minikube ip) \
+	-f values.yaml
 down:
 	minikube delete

--- a/README.md
+++ b/README.md
@@ -22,13 +22,41 @@ Run the dev container with the [VSCode extention][6] or the [devcontainer cli][7
 make up
 ```
 
+Wait until all pods are up and running. Before that you won't be able to access gitlab.
+Sometimes it takes 15-20 mins.
+
+You can monitor the pods status via:
+
+```shell
+kubectl get pods -w
+```
+
+Once the pods are running, run:
+
+```shell
+minikube ip
+```
+
+Open this URL in your browser, use the IP from the previous command:
+
+```shell
+https://gitlab.[minikube ip].nip.io/
+```
+
+Get the password to login:
+
+```shell
+kubectl get secret gitlab-gitlab-initial-root-password \
+-ojsonpath='{.data.password}' | base64 --decode ; echo
+```
+
 Destory environment:
 
 ```shell
 make down
 ```
 
-Stop the dev container
+* Note: The deployment is not yet accessible when running in a dev-container.
 
 [1]: https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovate
 [2]: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit

--- a/values.yaml
+++ b/values.yaml
@@ -1,10 +1,54 @@
+# values-minikube.yaml
+# This example intended as baseline to use Minikube for the deployment of GitLab
+# - Minimized CPU/Memory load, can fit into 3 CPU, 6 GB of RAM (barely)
+# - Services that are not compatible with how Minikube runs are disabled
+# - Some services entirely removed, or scaled down to 1 replica.
+# - Configured to use 192.168.99.100, and nip.io for the domain
+
+# Minimal settings
 global:
-  edition: ce
-  domain: example.com
-
-certmanager-issuer:
-  email: user@example.com
-
+  ingress:
+    configureCertmanager: false
+    class: "nginx"
+  hosts:
+    domain: 192.168.99.100.nip.io
+    externalIP: 192.168.99.100
+  # Disable Rails bootsnap cache (temporary)
+  rails:
+    bootsnap:
+      enabled: false
+  shell:
+    # Configure the clone link in the UI to include the high-numbered NodePort
+    # value from below (`gitlab.gitlab-shell.service.nodePort`)
+    port: 32022
+# Don't use certmanager, we'll self-sign
+certmanager:
+  install: false
+# Use the `ingress` addon, not our Ingress (can't map 22/80/443)
+nginx-ingress:
+  enabled: false
+# Save resources, only 3 CPU
+prometheus:
+  install: false
 gitlab-runner:
-  install: true
-  register: true
+  install: false
+# Reduce replica counts, reducing CPU & memory requirements
+gitlab:
+  webservice:
+    minReplicas: 1
+    maxReplicas: 1
+  sidekiq:
+    minReplicas: 1
+    maxReplicas: 1
+  gitlab-shell:
+    minReplicas: 1
+    maxReplicas: 1
+    # Map gitlab-shell to a high-numbered NodePort to support cloning over SSH since
+    # Minikube takes port 22.
+    service:
+      type: NodePort
+      nodePort: 32022
+registry:
+  hpa:
+    minReplicas: 1
+    maxReplicas: 1


### PR DESCRIPTION
There are some extra steps needed because it is install on minikube.
All info is here https://docs.gitlab.com/charts/development/minikube/.

Instructions for the PR:
After running `make up`,wait till all the pods are up and running, before that you won't be able to access the private gitlab. Sometimes it takes 15-20 mins.
Once all the pods are running (`kubectl get pods -w`)
run `minikube ip`
open this in your browser: `https://gitlab.[minikube ip].nip.io/`

Get the password to login: `kubectl get secret gitlab-gitlab-initial-root-password -ojsonpath='{.data.password}' | base64 --decode ; echo`
